### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,12 @@ If you don't want to use `import_map.json`, you may put `.vim-lsp-settings/setti
 Recommend to add `let g:markdown_fenced_languages = ['ts=typescript']` to your 
 vimrc for hover(preview) Deno's library.
 
+Note that `deno` language server is specified.
+
+```vim
+let g:lsp_settings_filetype_typescript = ['typescript-language-server', 'eslint-language-server', 'deno']
+```
+
 ### flow (JavaScript)
 
 To use flow, the `.flowconfig` has to be located on the top of project directory.


### PR DESCRIPTION
To use Deno, we need to set `g:lsp_settings_filetype_typescript`.